### PR TITLE
no odd-length datasets

### DIFF
--- a/data/aligned_dataset.py
+++ b/data/aligned_dataset.py
@@ -65,7 +65,7 @@ class AlignedDataset(BaseDataset):
                 'A_paths': AB_path, 'B_paths': AB_path}
 
     def __len__(self):
-        return len(self.AB_paths)
+        return len(self.AB_paths) // 2 * 2 # need pairs of examples; odd lengths only
 
     def name(self):
         return 'AlignedDataset'

--- a/data/single_dataset.py
+++ b/data/single_dataset.py
@@ -32,7 +32,7 @@ class SingleDataset(BaseDataset):
         return {'A': A, 'A_paths': A_path}
 
     def __len__(self):
-        return len(self.A_paths)
+        return len(self.A_paths) // 2 * 2
 
     def name(self):
         return 'SingleImageDataset'


### PR DESCRIPTION
an odd batch size causes problem in issue 21:
https://github.com/junyanz/BicycleGAN/issues/21

This happens at the end of the first epoch, with odd-sized datasets.

"RuntimeError: Trying to backward through the graph a second time, ...."

very quick solution is to delete a datum. the quick solution is to force dataset lengths to be even (as this request).